### PR TITLE
cacao integration and calibration

### DIFF
--- a/loadfits
+++ b/loadfits
@@ -1,4 +1,4 @@
-#Usage: ./loadfits /path/to/fitsfile.fits serial
+#usage: ./loadfits /path/to/fitsfile.fits <shared memory name>
 cacao << EOF
 loadfits "$1" im
 readshmim "$2"

--- a/setpix
+++ b/setpix
@@ -1,8 +1,8 @@
-#Usage: ./setpix val actnum serial
+#Usage: ./setpix val x y serial
 cacao << EOF
-readshmim "$3"
-creaim im1 2040 1
-setpix im1 $1 $2 0 
-cp im1 "$3"
+readshmim "$4"
+creaim im1 50 50
+setpix im1 $1 $2 $3
+cp im1 "$4"
 exit
 EOF


### PR DESCRIPTION
* updates command line options to handle biasing, linearizing stroke, and units
* now expects a 2D cacao image with a FITS file to map between the 1D vector and 2D image
* now supports inputs in microns of stroke and volume normalization